### PR TITLE
Fix mass assignment issue

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -51,6 +51,7 @@ class Site < ActiveRecord::Base
   
   after_create :create_homepage
   after_save :reload_routes
+  attr_protected :created_at, :updated_at
   
   # Returns the fully specified web address for the supplied path, or the root of this site if no path is given.
   

--- a/trusty-multi-site-extension.gemspec
+++ b/trusty-multi-site-extension.gemspec
@@ -4,7 +4,7 @@ require "trusty-multi-site-extension"
 
 Gem::Specification.new do |s|
   s.name        = "trusty-multi-site-extension"
-  s.version = "2.0.3"
+  s.version = "2.0.4"
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Sean Cribbs", "Eric Sipple", "Danielle Greaves"]
   s.description = %q{Extends Trusty CMS Layouts to support multiple sites, defined by domain}


### PR DESCRIPTION
I checked how we got around whitelisting custom fields whenever they were added to TrustyCMS' base Page model, and it was the slightly hacky but effective adding of attr_protected to created_at and updated_at. I did the same here for Site. 