### PR TITLE
Use Site Specific FileNotFoundPage

### DIFF
--- a/lib/multi_site/page_extensions.rb
+++ b/lib/multi_site/page_extensions.rb
@@ -17,7 +17,15 @@ module MultiSite::PageExtensions
         raise Page::MissingRootPageError unless root
         path = root.path if clean_path(path) == "/"
         result = root.find_by_path(path, live)
-        result.is_a?(FileNotFoundPage) ? get_site_specific_file_not_found(result) : result
+
+        # If the result is a FileNotFoundPage that doesn't match the current
+        # site, try to find one that does.
+        if result.is_a?(FileNotFoundPage) && result.site_id != homepage.site_id
+          get_site_specific_file_not_found(result)
+        else
+          result
+        end
+
       end
       def current_site
         @current_site ||= Site.default

--- a/lib/multi_site/page_extensions.rb
+++ b/lib/multi_site/page_extensions.rb
@@ -17,8 +17,7 @@ module MultiSite::PageExtensions
         raise Page::MissingRootPageError unless root
         path = root.path if clean_path(path) == "/"
         result = root.find_by_path(path, live)
-        # if the result is a FileNotFoundPage, make sure it's one for this site.
-        result.is_a?(FileNotFoundPage) ? FileNotFoundPage.where(site_id: homepage.site_id).first : result
+        result.is_a?(FileNotFoundPage) ? get_site_specific_file_not_found(result) : result
       end
       def current_site
         @current_site ||= Site.default
@@ -29,6 +28,14 @@ module MultiSite::PageExtensions
       def clean_path(path)
         "/#{ path.to_s.strip }/".gsub(%r{//+}, '/')
       end
+
+      # if the result is a FileNotFoundPage, try to find the one for this site.
+      # if you can't, return the initial result
+      def get_site_specific_file_not_found(result)
+        site_file_not_founds = FileNotFoundPage.where(site_id: homepage.site_id)
+        site_file_not_founds.any? ? site_file_not_founds.first : result
+      end
+
     end
   end
 

--- a/lib/multi_site/page_extensions.rb
+++ b/lib/multi_site/page_extensions.rb
@@ -16,7 +16,9 @@ module MultiSite::PageExtensions
         root = homepage
         raise Page::MissingRootPageError unless root
         path = root.path if clean_path(path) == "/"
-        root.find_by_path(path, live)
+        result = root.find_by_path(path, live)
+        # if the result is a FileNotFoundPage, make sure it's one for this site.
+        result.is_a?(FileNotFoundPage) ? FileNotFoundPage.where(site_id: homepage.site_id).first : result
       end
       def current_site
         @current_site ||= Site.default


### PR DESCRIPTION
# Problem

The way a `FileNotFoundPage` is discovered in TrustyCMS is to find the first child page that matches that class. This works fine on single site, but in cases in multi-site where you're trying to load the `FileNotFoundPage` of a parent site, a `FileNotFoundPage` of one of the child sites could be found instead.

# Solution

In cases where a `FileNotFoundPage` is returned, check to see if its `site_id` matches the current site. If not, try to find a `FileNotFoundPage` that's more appropriate. If that fails, return the `FileNotFoundPage` initially discovered.