### PR TITLE
Try to find a page under the site's homepage before returning a 404

### DIFF
--- a/lib/multi_site/page_extensions.rb
+++ b/lib/multi_site/page_extensions.rb
@@ -16,7 +16,6 @@ module MultiSite::PageExtensions
         root = homepage
         raise Page::MissingRootPageError unless root
         path = root.path if clean_path(path) == "/"
-        binding.pry
         result = root.find_by_path(path, live)
 
         # If it's a file not found page, see try adding the site homepage's

--- a/lib/multi_site/page_extensions.rb
+++ b/lib/multi_site/page_extensions.rb
@@ -18,21 +18,17 @@ module MultiSite::PageExtensions
         path = root.path if clean_path(path) == "/"
         result = root.find_by_path(path, live)
 
-        # If it's a file not found page, see try adding the site homepage's
-        # slug to the path and see if there's
-        if result.is_a?(FileNotFoundPage)
-          result = root.find_by_path("#{root.slug}/#{path}", live)
-        end
-
-        # If the result is still a FileNotFoundPage and it
+        # If the result is a FileNotFoundPage and it
         # doesn't match the current site, try to find one that does.
         if result.is_a?(FileNotFoundPage) && result.site_id != homepage.site_id
           get_site_specific_file_not_found(result)
+
+        # Otherwise, just go with it.
         else
           result
         end
-
       end
+
       def current_site
         @current_site ||= Site.default
       end

--- a/lib/multi_site/page_extensions.rb
+++ b/lib/multi_site/page_extensions.rb
@@ -16,10 +16,17 @@ module MultiSite::PageExtensions
         root = homepage
         raise Page::MissingRootPageError unless root
         path = root.path if clean_path(path) == "/"
+        binding.pry
         result = root.find_by_path(path, live)
 
-        # If the result is a FileNotFoundPage that doesn't match the current
-        # site, try to find one that does.
+        # If it's a file not found page, see try adding the site homepage's
+        # slug to the path and see if there's
+        if result.is_a?(FileNotFoundPage)
+          result = root.find_by_path("#{root.slug}/#{path}", live)
+        end
+
+        # If the result is still a FileNotFoundPage and it
+        # doesn't match the current site, try to find one that does.
         if result.is_a?(FileNotFoundPage) && result.site_id != homepage.site_id
           get_site_specific_file_not_found(result)
         else

--- a/lib/multi_site/site_controller_extensions.rb
+++ b/lib/multi_site/site_controller_extensions.rb
@@ -2,7 +2,20 @@ module MultiSite::SiteControllerExtensions
   def self.included(base)
     base.class_eval do
       before_filter :set_site
+      alias_method_chain :process_page, :home_path
     end
+  end
+
+  # If it's a file not found page and the path doesn't include
+  # the site's homepage path, try redirecting to include it.
+  def process_page_with_home_path(page)
+    homepage = Page.current_site.homepage
+    if page.is_a?(FileNotFoundPage) && !params[:url].include?(homepage.slug)
+      false if redirect_to "/#{homepage.slug}/#{params[:url]}"
+    else
+      process_page_without_home_path(page)
+    end
+
   end
   
   def set_site


### PR DESCRIPTION
# Problem

Page discovery by path in trusty is a little limited. In order to get to a site's page, you have look under the path of its homepage (i.e. `/pict_home/page` and not `/page`). This makes giving out urls for sites frustrating.

# Solution

When a `FileNotFoundPage` is returned, before returning it, search the page tree again by forcing the site's homepage slug into the path. Example:

1. Go to `http://pghkids.trustarts.org/page`
2. Do a `find_by_path('/page')`
3. No page is found, return a `FileNotFoundPage`
4. If the path doesn't contain the site's homepage slug, redirect to that path: `('/pict_home/page')`
5. Let nature take its course